### PR TITLE
Add a unit test to shoot a bug

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -244,6 +244,10 @@ export class SnapDatabase {
 
     public put(key: any, value: string) {
 
+        // if (typeof this._index.get(key) !== "undefined") {
+        //     this._index = this._index.remove(key)
+        // }
+
         // write key to index
         this._index = this._index.insert(key, NULLBYTE);
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -82,13 +82,34 @@ export const runTests = (testName: string, new_str: () => SnapDB<any>, new_int: 
             });
         }).timeout(30000);
 
-        it("Put Data Multiple Times for One Key", (done: MochaDone) => {
-            db_str.put('a', 'b')
-            .then(() => db_str.put('a', 'c'))
+        it("The count should be zero after puting then deleting", (done: MochaDone) => {
+            const KEY = 'key'
+            const VAL = 'val'
+            
+            db_str.put(KEY, VAL)
+            .then(() => db_str.delete(KEY))
             .then(() => db_str.getCount())
             .then(result => {
                 try {
-                    expect(result).to.deep.equal(1, "re-Put failed!");
+                    expect(result).to.equal(0, "put/del size failed!");
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            })
+        }).timeout(30000);
+
+        it("The count should be 1 after put data to the same key multiple times", (done: MochaDone) => {
+            const KEY = 'key'
+            const VAL = 'val'
+            
+            db_str.put(KEY, VAL)
+            .then(() => db_str.put(KEY, VAL))
+            .then(() => db_str.put(KEY, VAL))
+            .then(() => db_str.getCount())
+            .then(count => {
+                try {
+                    expect(count).to.equal(1, "Re-put failed!");
                     done();
                 } catch (e) {
                     done(e);

--- a/src/test.ts
+++ b/src/test.ts
@@ -82,6 +82,20 @@ export const runTests = (testName: string, new_str: () => SnapDB<any>, new_int: 
             });
         }).timeout(30000);
 
+        it("Put Data Multiple Times for One Key", (done: MochaDone) => {
+            db_str.put('a', 'b')
+            .then(() => db_str.put('a', 'c'))
+            .then(() => db_str.getCount())
+            .then(result => {
+                try {
+                    expect(result).to.deep.equal(1, "re-Put failed!");
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            })
+        }).timeout(30000);
+
         it("Get non-exist key", (done: MochaDone) => {
             db_str.get('non-exist-key').then((val) => {
                 try {


### PR DESCRIPTION
Related to https://github.com/huan/flash-store/issues/50

In SnapDB, set value to the same key more than one time will make the size wrong.

If we set the same key more than one time:

```javascript
await db.put('name', '1')
await db.put('name', '2')
await db.put('name', '3')
const size = await db.getCount() // size: 3
```
and then let's restart the script again, size: 4.
